### PR TITLE
chore: fix host source path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # ONYX Main Makefile
 ###############################################################################
 
-HOST_SOURCE_PATH=$(shell pwd)
+HOST_SOURCE_PATH=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 USER_ID=$(shell id -u)
 GROUP_ID=$(shell id -g)


### PR DESCRIPTION
`MAKEFILE_LIST` append the included other makefiles, so the first in the
list is the root makefile.

Related to #28