### PR TITLE
Allow karma env to be given as parameter or using an env var

### DIFF
--- a/makefiles/karma.mk
+++ b/makefiles/karma.mk
@@ -2,8 +2,21 @@
 # Karma
 #------------------------------------------------------------------------------
 
+# Spread cli arguments
+ifneq (,$(filter $(firstword $(MAKECMDGOALS)),config))
+    KARMA_CLI_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+    $(eval $(KARMA_CLI_ARGS):;@:)
+endif
+
+ifeq (,$(KARMA_CLI_ARGS))
+	KARMA_CLI_ARGS=$(shell grep 'KARMA_ENV=' .env | sed 's/KARMA_ENV=//g')
+	ifeq (,$(KARMA_CLI_ARGS))
+		KARMA_CLI_ARGS=dev
+	endif
+endif
+
 config: karma ## Run karma to configure for development environment
-	./karma hydrate -e dev
+	./karma hydrate -e $(KARMA_CLI_ARGS)
 
 karma:
 	$(eval LATEST_VERSION := $(shell curl -L -s -H 'Accept: application/json' https://github.com/niktux/karma/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/'))


### PR DESCRIPTION
1. Default behavior : `make config` will hydrate in the `dev` environment

2. Using the env var KARMA_ENV in the `.env` file :

```
KARMA_ENV=foo
```
3. Using a parameter for the make `config` target

```
make config foo
```
This will overwrite the `KARMA_ENV` value in the `.env` file if existing